### PR TITLE
Use Queue#pop(timeout:0) to avoid ThreadError

### DIFF
--- a/lib/ractor/shim.rb
+++ b/lib/ractor/shim.rb
@@ -177,12 +177,8 @@ if Ractor.shim?
               raise ArgumentError, "Unexpected argument for Ractor.select: #{ractor_or_port}"
             end
 
-            begin
-              value = queue.pop(true)
-              return [ractor_or_port, value]
-            rescue ThreadError
-              # keep looping
-            end
+            value = queue.pop(timeout: 0)
+            return [ractor_or_port, value] if value
           end
 
           # Wait until an item is added to a relevant Queue


### PR DESCRIPTION
pop(nonblock: true) raises ThreadError if no elements are available so switch to timeout:0 which just returns nil.

This might impact functionality if the queue is also expected to contain nils.